### PR TITLE
Change type export in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   "source": "src/index.ts",
   "exports": {
     "require": "./dist/index.cjs",
-    "default": "./dist/index.modern.js"
+    "default": "./dist/index.modern.js",
+    "types": "./dist/index.d.ts"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.module.js",
   "unpkg": "./dist/index.umd.js",
-  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
The module doesn't compile in Typescript because the type export is not set correctly.